### PR TITLE
Fixed typo/vimism

### DIFF
--- a/backend_ly.lisp
+++ b/backend_ly.lisp
@@ -208,7 +208,7 @@
     (:soprano-8dn . "\"soprano_8\"") (:tenor . "tenor") (:subbass-8up . "\"subbass^8\"") (:treble-8dn . "\"treble_8\"") (:alto . "alto") (:bass-8up . "\"bass^8\"")
     (:mezzosoprano . "mezzosoprano") (:c-baritone-8up . "\"baritone^8\"") (:f-baritone-8up . "\"varbaritone^8\"") (:soprano . "soprano") (:tenor-8up . "\"tenor^8\"")
     (:treble . "treble") (:alto-8up . "\"alto^8\"") (:mezzosoprano-8up . "\"mezzosoprano^8\"") (:soprano-8up . "\"soprano^8\"") (:treble-8up . "\"treble^8\"") (:treble-15up . "\"treble^15\"")
-    (:percussion . "percussion") (:tab . w"\"tab\"")))
+    (:percussion . "percussion") (:tab . "\"tab\"")))
 
 (defparameter +lilypond-keysigs+
   '((:cmaj . "c \\major") (:amin . "a \\minor")


### PR DESCRIPTION
There's a typo in backend_ly.lisp which prevents loading.